### PR TITLE
Make emoji filtering case insensitive

### DIFF
--- a/efck/emoji.py
+++ b/efck/emoji.py
@@ -75,6 +75,9 @@ def enum_emojis():
             seq, unicode_version, emoji, name = re.match(r'(.+?) ; (.+?) # ([^ ]+) (.+)', line).groups()
             official_emoji.add(emoji)
 
+            # Temporary workaround for country flags
+            name = name.lower()
+
             try:
                 alt_name = unicodedata.name(emoji, '').lower()
                 if alt_name == name:

--- a/efck/tabs/emoji.py
+++ b/efck/tabs/emoji.py
@@ -145,7 +145,7 @@ class EmojiTab(Tab):
 
         def set_text(self, text):
             self.filter_words = words = text.lower().split()
-            find_words_re = re.compile(fr'({"|".join(map(re.escape, words))})')
+            find_words_re = re.compile(fr'({"|".join(map(re.escape, words))})', flags=re.I)
             self.highlight_words = lambda text: find_words_re.sub(r'<b>\1</b>', text)
 
         def init(self, *, config, zoom, **kwargs):


### PR DESCRIPTION
Currently when filtering emoji, input strings are lowered first. Then they are compared with descriptions of those emoji. However, there are times that the description of a emoji contains upper-case characters. This happens a lot with national flags, since the first letter of the name of a country is usually in upper-case. For example, when searching for *china*, there is no chance that *China* will appear.

I just made a slight modification: when doing emoji filtering, compare lowered input letters with lowered emoji descriptions.

![image](https://user-images.githubusercontent.com/34163622/204235903-4355ff3a-6a8f-40ff-9f89-174de2693b35.png)
