### PR TITLE
fix: Ensure CornerWidget link color respects widget palette

### DIFF
--- a/efck/gui.py
+++ b/efck/gui.py
@@ -133,10 +133,6 @@ class MainWindow(_HasSizeGripMixin,
 
                 class Label(QLabel):
                     def __init__(self, parent):
-                        palette: QPalette = QApplication.instance().palette()
-                        palette.setColor(QPalette.ColorRole.Link,
-                                         palette.color(QPalette.ColorRole.WindowText))
-                        QApplication.instance().setPalette(palette)
                         super().__init__(
                             f'<a href="{__website__}"><b>EF*CK</b></a>',
                             textFormat=Qt.TextFormat.RichText,
@@ -145,6 +141,10 @@ class MainWindow(_HasSizeGripMixin,
                             openExternalLinks=True,
                             parent=parent,
                         )
+                        label_palette: QPalette = self.palette()
+                        label_palette.setColor(QPalette.ColorRole.Link,
+                                               label_palette.color(QPalette.ColorRole.WindowText))
+                        self.setPalette(label_palette)
 
                 self.layout().addWidget(Label(self))
 


### PR DESCRIPTION
This sets the Link color to match the widget's WindowText color, preventing interference with global application theming by not altering the QApplication palette.